### PR TITLE
allow 'Root' as an OU name to apply a stackset to all accounts in our Organization

### DIFF
--- a/source/manifest/manifest_parser.py
+++ b/source/manifest/manifest_parser.py
@@ -152,6 +152,10 @@ class StackSetParser:
         ou_ids_manifest = []
         # convert OU Name to OU IDs
         for ou_name in resource.deploy_to_ou:
+
+            if ou_name == 'Root':
+                accounts_in_ou.extend(accounts_in_all_ous)
+
             ou_id = [value for key, value in ou_name_to_id_map.items()
                      if ou_name == key]
             ou_ids_manifest.extend(ou_id)

--- a/source/state_machine_handler.py
+++ b/source/state_machine_handler.py
@@ -892,7 +892,11 @@ class ServiceControlPolicy(object):
         self.logger.info("Looking up the OU Id for OUName: {} with nested"
                          " ou delimiter: {}".format(nested_ou_name,
                                                     delimiter))
-        return self._get_ou_id(org, root_id, nested_ou_name, delimiter)
+        if nested_ou_name == 'Root':
+            self.logger.info("We want to apply this SCP to the Root level")
+            return root_id
+        else:
+            return self._get_ou_id(org, root_id, nested_ou_name, delimiter)
 
     def _get_ou_id(self, org, parent_id, nested_ou_name, delimiter):
         nested_ou_name_list = self._empty_separator_handler(


### PR DESCRIPTION
1.
Allow a Cloudformation Stackset to be deployed to all accounts in the AWS Organization with a single statement, in stead of having to supply all OUs or AccountIDs separately.
This code allows the use of
```
deploy_to_ou:
  - Root
```
in the manifest file.
The result is that the affected Cloudformation Stack will be deployed in every account under the AWS Organization, including the master account.

2.
Allow an SCP to be attached to the Root level of the AWS Organization with a single statement, in stead of having to supply all OUs separately.
This code allows the use of
```
apply_to_accounts_in_ou:
  - Root
```
in the manifest file.
The result is that the affected SCP is attached at the 'root' level of the AWS Organization, and consequently inherited by all OUs and accounts automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
