### PR TITLE
Implement targetting nested Organizational Units

### DIFF
--- a/source/manifest/sm_input_builder.py
+++ b/source/manifest/sm_input_builder.py
@@ -45,7 +45,7 @@ class SCPResourceProperties:
     """
     def __init__(self, policy_name, policy_description, policy_url, ou_list,
                  policy_list=None, account_id='', operation='',
-                 ou_name_delimiter=''):
+                 ou_name_delimiter=':'):
         self._policy_name = policy_name
         self._policy_description = policy_description
         self._policy_url = policy_url

--- a/source/tests/test_nested_ou.py
+++ b/source/tests/test_nested_ou.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from utils.logger import Logger
+from manifest.sm_input_builder import InputBuilder, SCPResourceProperties
+
+logger = Logger('info')
+
+# declare SCP state machine input variables
+name = "policy_name"
+description = "policy_description"
+policy_url = "https://s3.amazonaws.com/bucket/prefix"
+account_id = "account_id_1"
+policy_list = []
+operation = "operation_id"
+ou_list = [
+    [
+        "ou_name_1",
+        "Attach"
+    ],
+    [
+        "ou_name_2",
+        "Attach"
+    ]
+]
+
+def build_scp_input(name, description, policy_url,
+                    policy_list, account_id,
+                    operation, ou_list):
+    # get SCP output
+    resource_properties = SCPResourceProperties(name, description, policy_url,
+                                                policy_list, account_id,
+                                                operation, ou_list)
+    scp_input = InputBuilder(resource_properties.get_scp_input_map())
+    return scp_input.input_map()
+
+def test_default_delimiter():
+    scp_input = build_scp_input(name, description, policy_url,
+                                policy_list, account_id,
+                                operation, ou_list)
+    assert scp_input.get("ResourceProperties").get("OUNameDelimiter") == ':'


### PR DESCRIPTION
*Issue #19 : *

*Description of changes:*
AWS supports Organizational Units to a depth of 5. Organizational Units may be specified as the target for deployment of SCPs, but only at the level directly beneath the root of an Organization.

A delimiter character is mentioned in one test file, but the feature is not implemented.

Example specifying nested OU in manifest.yaml file:
```
organization_policies:
  - name: nested_scp
    policy_file: policies/policy-targetting-nested-ou.json
    #Apply to the following OU(s)
    apply_to_accounts_in_ou:
      - Parent-OU:Child-OU
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
