### PR TITLE
Print which SSM parameter was not found

### DIFF
--- a/source/aws/services/ssm.py
+++ b/source/aws/services/ssm.py
@@ -82,7 +82,11 @@ class SSM(Boto3Session):
             )
             return response.get('Parameter', {}).get('Value')
         except ClientError as e:
-            self.logger.log_unhandled_exception(e)
+            if e.response['Error']['Code'] == 'ParameterNotFound':
+                self.logger.log_unhandled_exception('The following SSM Parameter was not found: ', name)
+                self.logger.log_unhandled_exception(e)
+            else:
+                self.logger.log_unhandled_exception(e)
             raise
 
     def delete_parameter(self, name):


### PR DESCRIPTION
## Without this PR
When we have the following resource in the `manifest.yaml`:
```
- name: SomeIAMRole
  resource_file: templates/some-iam-role.template
  parameters:
    - parameter_key: "param1"
      parameter_value: "$[alfred_ssm_/my/path/to/param1]"
    - parameter_key: "param2"
      parameter_value: "$[alfred_ssm_/my/path/to/param2]"
```
and a SSM parameter does not exist, we get the following error:
```
An error occurred (ParameterNotFound) when calling the GetParameter operation:
```
And in result, we don't know which SSM Parameter is not found. 

## With this PR
The error would be:
```
The following SSM Parameter was not found:  /my/path/to/param2
An error occurred (ParameterNotFound) when calling the GetParameter operation:
```
This will make troubleshooting easier.

--- 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
