### PR TITLE
fix: incorrect usage instructions in build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ _Note:_ You would need to create one global bucket and one regional bucket. The 
  
 * Now build the distributable
 ``` 
-chmod +x ./build-s3-dist.sh
-./build-s3-dist.sh $DIST_OUTPUT_BUCKET_PREFIX $TEMPLATE_OUTPUT_BUCKET $SOLUTION_NAME $VERSION
+chmod +x ./deployment/build-s3-dist.sh
+./deployment/build-s3-dist.sh $DIST_OUTPUT_BUCKET_PREFIX $TEMPLATE_OUTPUT_BUCKET $SOLUTION_NAME $VERSION
 ``` 
  
 * Upload the distributable to an Amazon S3 bucket in your account.

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 # This assumes all of the OS-level configuration has been completed and git repo has already been cloned         
 #                                                                                                                
-# This script should be run from the repo's deployment directory                                                 
-# cd deployment                                                                                                  
-# ./build-s3-dist.sh source-bucket-base-name template-bucket-base-name trademarked-solution-name version-code                           
+# This script should be run from the repo's root directory                                                 
+# ./deployment/build-s3-dist.sh source-bucket-base-name template-bucket-base-name trademarked-solution-name version-code                           
 #                                                                                                                
 # Parameters:                                                                                                   
 #  - source-bucket-base-name: Name for the S3 bucket location where the template will source the Lambda          
 #    code from. The template will append '-[region_name]' to this bucket name.                                   
-#    For example: ./build-s3-dist.sh solutions template-bucket my-solution v1.0.0                                              
+#    For example: ./deployment/build-s3-dist.sh solutions template-bucket my-solution v1.0.0                                              
 #    The template will then expect the source code to be located in the solutions-[region_name] bucket           
 #  
 # - template-bucket-base-name: Name for the S3 bucket location where the template will be located                                                                                                           
@@ -20,7 +19,7 @@
 # Check to see if input has been provided:                                                                       
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
     echo "Please provide the base source bucket name, template-bucket, trademark approved solution name, and version"
-    echo "For example: ./build-s3-dist.sh solutions template-bucket trademarked-solution-name v1.0.0"
+    echo "For example: ./deployment/build-s3-dist.sh solutions template-bucket trademarked-solution-name v1.0.0"
     exit 1
 fi
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Script states it must be run from within the `deployment` directory. This is incorrect. It must be run from the root of the repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
