### PR TITLE
Add new stackset_name attribute

### DIFF
--- a/source/manifest/manifest.py
+++ b/source/manifest/manifest.py
@@ -129,6 +129,7 @@ class PolicyList(List):
 
 
 @yorm.attr(name=String)
+@yorm.attr(stackset_name=String)
 @yorm.attr(resource_file=String)
 @yorm.attr(parameter_file=String)
 @yorm.attr(deploy_method=String)
@@ -138,9 +139,11 @@ class PolicyList(List):
 @yorm.attr(parameters=Parameters)
 class ResourceProps(AttributeDictionary):
     def __init__(self, name, resource_file, parameters, parameter_file,
-                 deploy_method, deployment_targets, export_outputs, regions):
+                 deploy_method, deployment_targets, export_outputs, regions,
+                 stackset_name=None):
         super().__init__()
         self.name = name
+        self.stackset_name = stackset_name
         self.resource_file = resource_file
         self.parameter_file = parameter_file
         self.parameters = parameters

--- a/source/manifest/manifest_parser.py
+++ b/source/manifest/manifest_parser.py
@@ -376,7 +376,10 @@ class BuildStateMachineInput:
         ssm_parameters = self._create_ssm_input_map(resource.export_outputs)
 
         # generate state machine input list
-        stack_set_name = "CustomControlTower-{}".format(resource.name)
+        if resource.stackset_name:
+            stack_set_name = "CustomControlTower-{}".format(resource.stackset_name)
+        else:
+            stack_set_name = "CustomControlTower-{}".format(resource.name)
         resource_properties = StackSetResourceProperties(stack_set_name,
                                                          template_url,
                                                          sm_params,


### PR DESCRIPTION
Overrides the use of the name attribute when deriving the name of the
StackSet.  Supports the ability to refactor code and avoid triggering a
deletion of a StackSet.

*Issue #, if available:* #95 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
