### PR TITLE
(fix) Add missing S3 perms for CustomControlTowerCodePipelineRole to allow source fetch

### DIFF
--- a/customizations-for-aws-control-tower.template
+++ b/customizations-for-aws-control-tower.template
@@ -478,6 +478,9 @@ Resources:
                   - s3:PutObject
                   - s3:GetObject
                   - s3:GetObjectVersion
+                  - s3:GetObjectVersionTagging
+                  - s3:ListBucket
+                  - s3:PutObjectTagging
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${CustomControlTowerPipelineArtifactS3Bucket}/*
                   - !Sub arn:${AWS::Partition}:s3:::${CustomControlTowerPipelineS3Bucket}/*


### PR DESCRIPTION
When the Custom-Control-Tower-CodePipeline starts running, the `Source` stage fails because the CodePipeline role doesn't have the enough perms to fetch the `custom-control-tower-configuration.zip` artifact.

These new permissions solves the AccessDenied error.