### PR TITLE
(fix) urllib3 update for CVE vulnerabilities

### DIFF
--- a/source/src/setup.py
+++ b/source/src/setup.py
@@ -34,8 +34,9 @@ setuptools.setup(
         "requests==2.32.4",
         "markdown_to_json==1.0.0",
         "python-dateutil==2.8.1",
-        "boto3==1.34.162",
-        "botocore==1.34.162",
+        "boto3==1.42.35",
+        "botocore==1.42.35",
+        "urllib3>=2.2.3,<3",  # CVE-2025-66418 fix
     ],
     extras_require={
         "test": [

--- a/source/src/setup.py
+++ b/source/src/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "python-dateutil==2.8.1",
         "boto3==1.42.35",
         "botocore==1.42.35",
-        "urllib3>=2.2.3,<3",  # CVE-2025-66418 fix
+        "urllib3>=2.2.3,<3",  # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441 fix
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Using AWS Security Hub, it reported CVE vulnerabilities in 2 Lambda functions (State Machine, Lifecycle Event processor).

https://github.com/advisories/GHSA-gm62-xv2j-4w53
https://github.com/advisories/GHSA-2xpw-w6gg-jr37
https://github.com/advisories/GHSA-38jv-5279-wg99

This is in the urllib3 library which is used by boto3 and botocore. This is specified in the setup.py file during build time. Which will generate new zip files for the Lambda functions.

# Contributing to Customizations for AWS Control Tower (CfCT).

Thank you for your interest in contributing to Customizations for AWS Control Tower (CfCT).

At this time, we are not accepting contributions. If contributions are accepted in the future, Customizations for AWS Control Tower (CfCT) is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
